### PR TITLE
feat: implement logic of backend calls 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,6 +4161,7 @@ dependencies = [
  "js-sys",
  "serde",
  "serde-wasm-bindgen 0.6.5",
+ "shield-circuit",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/circuit/src/merkle.rs
+++ b/circuit/src/merkle.rs
@@ -76,7 +76,7 @@ where
     }
 
     pub fn num_levels() -> u32 {
-        u64::BITS
+        u32::BITS
     }
 
     pub fn root(&self) -> Result<Hash, MerkleError> {

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -16,3 +16,5 @@ js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1.7"
+
+shield-circuit = { path = "../circuit", version = "*" }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -50,7 +50,7 @@ pub fn app() -> Html {
             let nullifier = nullifier.clone();
             let js_args = to_value(&DepositParams { recipiant: 456 }).unwrap();
             spawn_local(async move {
-                let nullifier_str = unsafe { invoke("deposit", js_args) }.await;
+                let nullifier_str = invoke("deposit", js_args).await;
                 nullifier.set(nullifier_str.as_string().unwrap());
             });
         })
@@ -68,7 +68,7 @@ pub fn app() -> Html {
             let nullifier = nullifier.clone();
             let js_args = to_value(&WithdrawParams::from_hex_str(nullifier.to_string())).unwrap();
             spawn_local(async move {
-                let nullifier_str = unsafe { invoke("withdraw", js_args) }.await;
+                let nullifier_str = invoke("withdraw", js_args).await;
                 nullifier.set(nullifier_str.as_string().unwrap());
             });
         })

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
+use serde_wasm_bindgen::to_value;
 
 const DEFAULT_BALANCE: u64 = 100;
 const DEFAULT_DEPOSITED: u64 = 10;
@@ -39,12 +40,19 @@ pub fn app() -> Html {
 
     let deposit_click = {
         let shielded_accounts = shielded_accounts.clone();
+        let nullifier = nullifier.clone();
         Callback::from(move |(new_shielded_addr, deposit_amount)| {
             let mut accounts = shielded_accounts.to_vec();
             accounts.push(AccountState::new(new_shielded_addr, 0, deposit_amount));
             shielded_accounts.set(accounts);
 
-            // TODO: call deposit function of backend
+            // call deposit function of backend
+            let nullifier = nullifier.clone();
+            let js_args = to_value(&DepositParams { recipiant: 456 }).unwrap();
+            spawn_local(async move {
+                let nullifier_str = invoke("deposit", js_args).await;
+                nullifier.set(nullifier_str.as_string().unwrap());
+            });
         })
     };
 

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -69,7 +69,7 @@ pub fn app() -> Html {
             let js_args = to_value(&WithdrawParams::from_hex_str(nullifier.to_string())).unwrap();
             spawn_local(async move {
                 let nullifier_str = invoke("withdraw", js_args).await;
-                nullifier.set(nullifier_str.as_string().unwrap());
+                nullifier.set(nullifier_str.as_bool().unwrap().to_string());
             });
         })
     };

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -50,7 +50,7 @@ pub fn app() -> Html {
             let nullifier = nullifier.clone();
             let js_args = to_value(&DepositParams { recipiant: 456 }).unwrap();
             spawn_local(async move {
-                let nullifier_str = invoke("deposit", js_args).await;
+                let nullifier_str = unsafe { invoke("deposit", js_args) }.await;
                 nullifier.set(nullifier_str.as_string().unwrap());
             });
         })

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -88,7 +88,7 @@ pub fn app() -> Html {
           </div>
 
           <div class="nullifier-container">
-            <label for="nullifier" class="nullifier-label">{"Nullifier"}</label>
+            <label for="nullifier" class="nullifier-label"><strong>{"nullifier"}</strong></label>
             <p id="nullifier" class="nullifier-text" readonly=true>{nullifier.to_string()}</p>
           </div>
 

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -25,6 +25,8 @@ pub fn app() -> Html {
         ]
     });
 
+    let nullifier = use_state(|| "".to_string());
+
     // {
     //     let mut unshielded_accounts = unshielded_accounts.to_vec();
     //     use_effect(move || {
@@ -69,6 +71,12 @@ pub fn app() -> Html {
               }
             }).collect::<Html>()}
           </div>
+
+          <div class="nullifier-container">
+            <label for="nullifier" class="nullifier-label">{"Nullifier"}</label>
+            <p id="nullifier" class="nullifier-text" readonly=true>{nullifier.to_string()}</p>
+          </div>
+
           <h1 class="accounts-title">{"Shielded accounts"}</h1>
           <div class="accounts-list">
             {shielded_accounts.iter().map(|AccountState { address, deposited, .. }| {

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -27,6 +27,7 @@ pub fn app() -> Html {
     });
 
     let nullifier = use_state(|| "".to_string());
+    let withdrawn_status = use_state(|| "".to_string());
 
     // {
     //     let mut unshielded_accounts = unshielded_accounts.to_vec();
@@ -59,6 +60,7 @@ pub fn app() -> Html {
     let withdraw_click = {
         let shielded_accounts = shielded_accounts.clone();
         let nullifier = nullifier.clone();
+        let withdrawn_status = withdrawn_status.clone();
         Callback::from(move |shielded_addr: String| {
             let mut accounts = shielded_accounts.to_vec();
             accounts.retain(|a| a.address != shielded_addr);
@@ -67,9 +69,10 @@ pub fn app() -> Html {
             // call withdraw function of backend
             let nullifier = nullifier.clone();
             let js_args = to_value(&WithdrawParams::from_hex_str(nullifier.to_string())).unwrap();
+            let withdrawn_status = withdrawn_status.clone();
             spawn_local(async move {
-                let nullifier_str = invoke("withdraw", js_args).await;
-                nullifier.set(nullifier_str.as_bool().unwrap().to_string());
+                let withdrawn_res = invoke("withdraw", js_args).await;
+                withdrawn_status.set(withdrawn_res.as_bool().unwrap().to_string());
             });
         })
     };
@@ -90,6 +93,7 @@ pub fn app() -> Html {
           <div class="nullifier-container">
             <label for="nullifier" class="nullifier-label"><strong>{"nullifier"}</strong></label>
             <p id="nullifier" class="nullifier-text" readonly=true>{nullifier.to_string()}</p>
+            <p><strong>{"withdrawn? "}{withdrawn_status.to_string()}</strong></p>
           </div>
 
           <h1 class="accounts-title">{"Shielded accounts"}</h1>

--- a/ui/src/bindgen.rs
+++ b/ui/src/bindgen.rs
@@ -8,6 +8,6 @@ extern "C" {
     #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], js_name = invoke)]
     pub async fn invoke_without_args(cmd: &str) -> JsValue;
 
-    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], js_name = invoke)]
     pub async fn invoke(cmd: &str, args: JsValue) -> JsValue;
 }

--- a/ui/src/util/mod.rs
+++ b/ui/src/util/mod.rs
@@ -1,5 +1,6 @@
-use yew::{Callback, Properties};
 use serde::Serialize;
+use shield_circuit::Hash;
+use yew::{Callback, Properties};
 
 #[derive(Debug, Clone)]
 pub struct AccountState {
@@ -34,5 +35,18 @@ pub struct ShieldAccountProps {
 
 #[derive(Serialize)]
 pub struct DepositParams {
-    recipiant: u64,
+    pub(crate) recipiant: u64,
+}
+
+#[derive(Serialize)]
+pub struct WithdrawParams {
+    pub(crate) nullifier: Hash,
+}
+
+impl WithdrawParams {
+    pub fn from_hex_str(nullifier: String) -> Self {
+        Self {
+            nullifier: Hash::from_hex(nullifier),
+        }
+    }
 }

--- a/ui/src/util/mod.rs
+++ b/ui/src/util/mod.rs
@@ -1,4 +1,5 @@
 use yew::{Callback, Properties};
+use serde::Serialize;
 
 #[derive(Debug, Clone)]
 pub struct AccountState {
@@ -29,4 +30,9 @@ pub struct ShieldAccountProps {
     pub address: String,
     pub deposited: u64,
     pub withdraw_clicked: Callback<String>,
+}
+
+#[derive(Serialize)]
+pub struct DepositParams {
+    recipiant: u64,
 }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -64,6 +64,20 @@
     cursor: pointer;
 }
 
+.nullifier-container {
+    margin-top: 10px;
+    padding: 5px;
+    border: 1px solid #ddd;
+}
+
 #nullifier {
     border: 1px solid #ddd;
+    height: 50px; /* Fixed height */
+    padding: 5px; /* Optional: Padding inside the box */
+    border: 1px solid #ccc; /* Optional: Border for visibility */
+    border-radius: 5px; /* Optional: Rounded corners */
+    overflow-wrap: break-word; /* Allows long words to break to the next line */
+    word-break: break-word; /* Breaks long words at word boundaries */
+    text-align: left; /* Left-align the text horizontally */
+    display: flex; /* Enables flexbox */
 }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -63,3 +63,7 @@
     border-radius: 4px; 
     cursor: pointer;
 }
+
+#nullifier {
+    border: 1px solid #ddd;
+}


### PR DESCRIPTION
## Changes
- implement the logic of calling the `deposit/withdraw` tauri function from ui button click
- update the default `num_level` constant in `DenseMerkleTree` in `circuit` crate
- add some ui elements for showing the `nullifier` and `withdraw` result